### PR TITLE
Fix rake download

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ end
 
 desc 'download data'
 task :download do
+  sh "mkdir #{SRC_DIR}" unless File.exist?("#{SRC_DIR}")
   File.foreach(URLS_PATH) {|l|
     url = l.strip
     path = "#{SRC_DIR}/#{url.split('/')[-1]}"


### PR DESCRIPTION
Hi, when I run `rake download`, it displayed error message below. So, I add the program to create `src` directory if it is not exist.

@hfu May I ask you to review it? Thank you!

```
[naoppy@n a-1 (main)]$ rake download
curl -o src/000153778.zip https://www.gsi.go.jp/antarctic/contents/000153778.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to create the file src/000153778.zip: No such file or 
Warning: directory
  0 4609k    0 16384    0     0  96792      0  0:00:48 --:--:--  0:00:48 99902
curl: (23) Failure writing output to destination
rake aborted!
Command failed with status (23): [curl -o src/000153778.zip https://www.gsi....]
/Users/naoppy/Desktop/a-1/Rakefile:20:in `block (2 levels) in <top (required)>'
/Users/naoppy/Desktop/a-1/Rakefile:17:in `foreach'
/Users/naoppy/Desktop/a-1/Rakefile:17:in `block in <top (required)>'
Tasks: TOP => download
(See full trace by running task with --trace)
```